### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ prototype object, and you're set:
 
 ```php
 use PhlyMongo\HydratingMongoCursor;
-use Zend\Stdlib\ObjectProperty;
+use Zend\Stdlib\Hydrator\ObjectProperty;
 
 class Status
 {


### PR DESCRIPTION
changed "use Zend\Stdlib\ObjectProperty;" to "use Zend\Stdlib\Hydrator\ObjectProperty;"
