### PR TITLE
Utilize MongoClient() if exists as Mongo() is depricated

### DIFF
--- a/src/PhlyMongo/MongoConnectionFactory.php
+++ b/src/PhlyMongo/MongoConnectionFactory.php
@@ -8,12 +8,8 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 
 class MongoConnectionFactory implements FactoryInterface
 {
-
     protected $server = 'mongodb://localhost:27017';
-
-    protected $options = array(
-        'connect' => true
-    );
+    protected $options = array('connect' => true);
 
     public function __construct($server = null, array $options = null)
     {


### PR DESCRIPTION
Mongo() is deprecated as of 1.3.0 of the driver. The preferred connection method is MongoClient() now.
