### PR TITLE
add missing zf component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "ext-mongo": "*",
         "zendframework/zend-paginator": "2.*",
         "zendframework/zend-servicemanager": "2.*",
-        "zendframework/zend-stdlib": "2.*"
+        "zendframework/zend-stdlib": "2.*",
+        "zendframework/zend-i18n": "2.*"
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "*@dev",


### PR DESCRIPTION
Since ZF 2.4, this module doesn't work anymore without zend-i18n component.